### PR TITLE
Fixed error where the Risk Assessment gauge incremented forever.

### DIFF
--- a/public/js/risk.js
+++ b/public/js/risk.js
@@ -20,7 +20,7 @@ let progress = setInterval(() => {
     progressValue.textContent = `${progressStartValue}%`;
     circularProgress.style.background = `conic-gradient( #F9858b ${progressStartValue * 3.6}deg, #efefef 0deg)`
 
-    if (progressStartValue == progressEndValue) {
+    if (progressStartValue == Math.trunc(progressEndValue)) {
         clearInterval(progress);
     }
 }, speed);


### PR DESCRIPTION
The bug occurs when the risk value is a floating point value, as the stop condition assumes that the progress value and the risk value are integers. 